### PR TITLE
Destroy tests promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+* 2.1.1: `apos.destroy` now closes the Redis connection, for compatibility with
+`apostrophe-monitor` and `apostrophe-multisite`. Corrections were made to the
+unit tests for promises (the actual implementation code for promises was fine).
+`mocha` 5.x is used, addressing reported vulnerabilities from `npm audit`,
+although in actuality the vulnerable modules were only used by the test runner. 
+
+* 2.1.0: promise support. The `get`, `set` and `clear` methods of caches now return promises if no callback is given, matching the behavior of Apostrophe's core cache.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,3 @@ See the [redis npm module documentation](https://www.npmjs.com/package/redis) fo
 
 You can do that too, and it greatly reduces the load on MongoDB. You don't need this module for that. See [storing sessions in Redis](http://apostrophecms.org/docs/tutorials/howtos/storing-sessions-in-redis.html).
 
-## Changelog
-
-2.1.0: promise support. The `get`, `set` and `clear` methods of caches now return promises if no callback is given, matching the behavior of Apostrophe's core cache.

--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ module.exports = {
   improve: 'apostrophe-caches',
 
   construct: function(self, options) {
+    self.on('apostrophe:destroy', 'closeRedisConnection', function() {
+      self.client.stream.removeAllListeners();
+      self.client.stream.destroy();
+    });
     // Replace the apostrophe-caches implementation of getCollection in a bc way
     self.getCollection = function(callback) {
       var redisOptions = options.redis || {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-caches-redis",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Redis-based cache for the Apostrophe CMS",
   "main": "index.js",
   "scripts": {
@@ -22,11 +22,11 @@
   },
   "homepage": "https://github.com/punkave/apostrophe-cache-redis#readme",
   "dependencies": {
-    "bluebird": "^3.5.1",
+    "bluebird": "^3.5.3",
     "redis": "^2.8.0"
   },
   "devDependencies": {
-    "apostrophe": "^2.0.0",
-    "mocha": "^3.5.3"
+    "apostrophe": "^2.75.1",
+    "mocha": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/punkave/apostrophe-cache-redis.git"
+    "url": "git+https://github.com/apostrophecms/apostrophe-cache-redis.git"
   },
   "keywords": [
     "apostrophe",
@@ -18,9 +18,9 @@
   "author": "P'unk Avenue LLC",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/punkave/apostrophe-cache-redis/issues"
+    "url": "https://github.com/apostrophecms/apostrophe-cache-redis/issues"
   },
-  "homepage": "https://github.com/punkave/apostrophe-cache-redis#readme",
+  "homepage": "https://github.com/apostrophecms/apostrophe-cache-redis#readme",
   "dependencies": {
     "bluebird": "^3.5.3",
     "redis": "^2.8.0"

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,11 @@ describe('Apostrophe cache implementation in redis', function() {
   var apos;
   var cache1;
   var cache2;
+
+  after(function(done) {
+    require('apostrophe/test-lib/util').destroy(apos, done);
+  });
+
   it('initializes apostrophe', function(done) {
     this.timeout(5000);
     apos = require('apostrophe')({
@@ -179,9 +184,8 @@ describe('Apostrophe cache implementation in redis', function() {
     return cache1.set('timeout', 'timeout', 1);
   });
   it('can fetch that key within the 1-second timeout with promises', function() {
-    return cache1.get('timeout', function(value) {
+    return cache1.get('timeout').then(function(value) {
       assert(value === 'timeout');
-      done();
     });
   });
   it('cannot fetch that key after 2 seconds with promises', function() {


### PR DESCRIPTION
2.1.1: `apos.destroy` now closes the Redis connection, for compatibility with
`apostrophe-monitor` and `apostrophe-multisite`. Corrections were made to the
unit tests for promises (the actual implementation code for promises was fine).
`mocha` 5.x is used, addressing reported vulnerabilities from `npm audit`,
although in actuality the vulnerable modules were only used by the test runner.