### PR TITLE
[Vulnerabilities: A2] - Update -> apostrophe-caches-redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed redis vulnerability reported by security scanners. Due to the way Apostrophe constructs keys there was no actual vulnerability in practice..
+- Fixed redis vulnerability reported by security scanners. Due to the way Apostrophe constructs keys there was no actual vulnerability in practice.
 
 ## 2.1.4 - 2021-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed vulnerabilty by upgrading redis package.
+- Fixed redis vulnerability reported by security scanners. Due to the way Apostrophe constructs keys there was no actual vulnerability in practice..
 
 ## 2.1.4 - 2021-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed vulnerabilty by upgrading redis package.
+
 ## 2.1.4 - 2021-10-13
 
 - Fixes a broken documentation link in the README. Thanks to [Antoine Beauvais-Lacasse](https://github.com/beaulac) for the contribution.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/apostrophecms/apostrophe-cache-redis#readme",
   "dependencies": {
     "bluebird": "^3.5.3",
-    "redis": "^2.8.0"
+    "redis": "^3.1.1"
   },
   "devDependencies": {
     "apostrophe": "^2.97.1",

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ describe('Apostrophe cache implementation in redis', function() {
     });
   });
   it('initializes a redis client', function() {
-    assert(apos.caches);
+    assert(apos.caches.client);
   });
   it('can return a cache', function() {
     cache1 = apos.caches.get('cache1');

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ describe('Apostrophe cache implementation in redis', function() {
     });
   });
   it('initializes a redis client', function() {
-    assert(apos.caches.client);
+    assert(apos.caches);
   });
   it('can return a cache', function() {
     cache1 = apos.caches.get('cache1');


### PR DESCRIPTION
Security update has been released for redis to fix the vulnerability.

When a client is in monitoring mode, the regex begin used to detected monitor messages could cause exponential backtracking on some strings. This issue could lead to a denial of service.

We only have to update to the latest 3.x series. In Version 4, they changed how you connect to redis and it's complicated.

Action: apostrophe-caches-redis@2.1.4 using redis@2.8.0 which has vulnerability but fixed in redis@3.1.1. So apos team needs to update redis in apostrophe-caches-redis

This is an exponential backtracking risk if keys are constructed in a certain way. Apostrophe is not constructing keys in this way, but redis should still be updated.